### PR TITLE
Disable automation in ESRI Config Addin

### DIFF
--- a/arcgis10_mapping_tools/MapActionToolbars/Config.esriaddinx
+++ b/arcgis10_mapping_tools/MapActionToolbars/Config.esriaddinx
@@ -19,7 +19,7 @@
             <Button refID="MapAction_LayoutTool" />
             <Button refID="MapAction_ExportTool" />
             <Button refID="MapAction_RenameTool" />
-            <Button refID="MapAction_GenerationTool" />
+            <!--<Button refID="MapAction_GenerationTool" /> -->
             <Button refID="MapAction_About_Box" />
           </Items>
         </Toolbar>

--- a/arcgis10_mapping_tools/MapActionToolbars/frmEvent.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmEvent.cs
@@ -244,7 +244,7 @@ namespace MapActionToolbars
             EventConfig newConfig = MapAction.Utilities.getEventConfigValues(path);
 
             //Populate the text boxes with the values from the dictionary
-            tbxPathToCrashMove.Text = newConfig.CrashMoveFolderDescriptorPath;
+            //tbxPathToCrashMove.Text = newConfig.CrashMoveFolderDescriptorPath;
             tbxOperationName.Text = newConfig.OperationName;
             tbxGlideNo.Text = newConfig.GlideNumber;
             cboTimeZone.Text = newConfig.TimeZone;

--- a/arcgis10_mapping_tools/MapActionToolbars/frmEvent.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmEvent.cs
@@ -244,7 +244,6 @@ namespace MapActionToolbars
             EventConfig newConfig = MapAction.Utilities.getEventConfigValues(path);
 
             //Populate the text boxes with the values from the dictionary
-            //tbxPathToCrashMove.Text = newConfig.CrashMoveFolderDescriptorPath;
             tbxOperationName.Text = newConfig.OperationName;
             tbxGlideNo.Text = newConfig.GlideNumber;
             cboTimeZone.Text = newConfig.TimeZone;


### PR DESCRIPTION
Used the ESRI Config to disable MapAutomation until we are ready to deploy laptops with productionised Map Automation.

The delivered ESRI-Add-In for this version of the code is here:
https://drive.google.com/drive/u/0/folders/1pDgCkeRt4OwddPEmYBJt3jyhEbhjxKmC

Fixes #

When specifying the Crash Move Folder path, it appended the file name, which was incorrect behaviour.