### PR TITLE
Bugfix/zfill version

### DIFF
--- a/arcgis10_mapping_tools/MapActionToolbars/AboutBox.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/AboutBox.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.IO;
 using System.Windows.Forms;
 using System.Reflection;
-
+using System.Linq;
 
 namespace MapActionToolbars
 {
@@ -25,8 +25,13 @@ namespace MapActionToolbars
             DateTime compile_date = new DateTime(2000, 1, 1);
             compile_date = compile_date.AddDays(an.Version.Build);
             compile_date = compile_date.AddSeconds(2 * an.Version.Revision);
-
-            m_thisaddin_desc = String.Format("Version {0}\n\n Compiled {1} {2}", version_string, compile_date.ToShortDateString(), compile_date.ToShortTimeString());
+            // Get the git commit reference of the code this version was compiled from. 
+            // See targets added to MapActionToolbars.csproj, from https://stackoverflow.com/a/45248069/4150190
+            var asm = Assembly.GetExecutingAssembly();
+            var attrs = asm.GetCustomAttributes<AssemblyMetadataAttribute>();
+            var githash = attrs.FirstOrDefault(a => a.Key == "GitHash")?.Value;
+            m_thisaddin_desc = String.Format("Version {0}\n\n Compiled {1} {2} \n\n Source code revision: {3}", 
+                version_string, compile_date.ToShortDateString(), compile_date.ToShortTimeString(), githash);
         }
 
         protected override void OnClick()

--- a/arcgis10_mapping_tools/MapActionToolbars/MapActionToolbars.csproj
+++ b/arcgis10_mapping_tools/MapActionToolbars/MapActionToolbars.csproj
@@ -346,7 +346,44 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  -->
+  --><Target Name="GetGitHash" BeforeTargets="WriteGitHash" Condition="'$(BuildHash)' == ''">
+  <PropertyGroup>
+    <!-- temp file for the git version (lives in "obj" folder)-->
+    <VerFile>$(IntermediateOutputPath)gitver</VerFile>
+  </PropertyGroup>
+
+  <!-- write the hash to the temp file.-->
+  <Exec Command="git -C $(ProjectDir) describe --long --always --dirty &gt; $(VerFile)" />
+
+  <!-- read the version into the GitVersion itemGroup-->
+  <ReadLinesFromFile File="$(VerFile)">
+    <Output TaskParameter="Lines" ItemName="GitVersion" />
+  </ReadLinesFromFile>
+  <!-- Set the BuildHash property to contain the GitVersion, if it wasn't already set.-->
+  <PropertyGroup>
+    <BuildHash>@(GitVersion)</BuildHash>
+  </PropertyGroup>    
+</Target>
+
+<Target Name="WriteGitHash" BeforeTargets="CoreCompile">
+  <!-- names the obj/.../CustomAssemblyInfo.cs file -->
+  <PropertyGroup>
+    <CustomAssemblyInfoFile>$(IntermediateOutputPath)CustomAssemblyInfo.cs</CustomAssemblyInfoFile>
+  </PropertyGroup>
+  <!-- includes the CustomAssemblyInfo for compilation into your project -->
+  <ItemGroup>
+    <Compile Include="$(CustomAssemblyInfoFile)" />
+  </ItemGroup>
+  <!-- defines the AssemblyMetadata attribute that will be written -->
+  <ItemGroup>
+    <AssemblyAttributes Include="AssemblyMetadata">
+      <_Parameter1>GitHash</_Parameter1>
+      <_Parameter2>$(BuildHash)</_Parameter2>
+    </AssemblyAttributes>
+  </ItemGroup>
+  <!-- writes the attribute to the customAssemblyInfo file -->
+  <WriteCodeFragment Language="C#" OutputFile="$(CustomAssemblyInfoFile)" AssemblyAttributes="@(AssemblyAttributes)" />
+</Target>
   <Target Name="AfterBuild">
     <!-- Gives build warning when add-in targets file is not found. -->
     <Warning Text="Unable to create .esriAddin; missing ESRI ArcGIS Add-in SDK component(s)." Condition="!Exists('$(MSBuildExtensionsPath)\ESRI\ESRI.ArcGIS.AddIns.targets')" />

--- a/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
@@ -550,7 +550,7 @@ namespace MapActionToolbars
             }
 
             var res = tryParseMapNumberVersionFromFilename();
-            if (!(res is null) && res.Item1 != this.tbxMapNumber.Text || res.Item2 != getPaddedVersionNumberString())
+            if (!(res is null) && (res.Item1 != this.tbxMapNumber.Text || res.Item2 != getPaddedVersionNumberString()))
             {
                 var yesorno = MessageBox.Show(
                     "The Map number/and or version described in this MXD filename don't seem " + //Environment.NewLine +

--- a/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
@@ -316,7 +316,7 @@ namespace MapActionToolbars
             // Presume Initial Version
             cboStatus.Text = _statusNew;
 
-            string vString = "V" + this.tbxVersionNumber.Text;
+            string vString = getPaddedVersionNumberString();
             string[] xmlPathParts = { tbxExportZipPath.Text, this.tbxMapNumber.Text, vString,
                 System.IO.Path.GetFileNameWithoutExtension(tbxMapDocument.Text) + ".xml" };
             
@@ -325,7 +325,7 @@ namespace MapActionToolbars
             if (!File.Exists(xmlPath))
             {
                 // look at the xml for the previous version's export if an export of this version does not already exist
-                vString = "V" + (int.Parse(this.tbxVersionNumber.Text) - 1);
+                vString = getPaddedVersionNumberString(-1);
                 xmlPathParts[2] = vString;
                 xmlPath = System.IO.Path.Combine(xmlPathParts);
             }
@@ -482,6 +482,12 @@ namespace MapActionToolbars
             return allFiles.Length > countFilesToOverwrite(folderPath);
         }
 
+        private String getPaddedVersionNumberString(int offset=0)
+        {
+            var int_version = int.Parse(this.tbxVersionNumber.Text) + offset;
+            return "v" + int_version.ToString("D2");
+        }
+
         private void btnCreateZip_Click(object sender, EventArgs e)
         {
             // The main export function
@@ -521,7 +527,7 @@ namespace MapActionToolbars
                 return;
             }
 
-            string[] pathParts = { basePath, this.tbxMapNumber.Text, "V" + this.tbxVersionNumber.Text };
+            string[] pathParts = { basePath, this.tbxMapNumber.Text, getPaddedVersionNumberString()};
             var exportFolder = System.IO.Path.Combine(pathParts);
 
             Directory.CreateDirectory(exportFolder);
@@ -775,8 +781,10 @@ namespace MapActionToolbars
                             string qrCodeImagePath = Utilities.GenerateQRCode(this._mapRootURL + tbxOperationId.Text.ToLower() +
                                                                               "-" + tbxMapNumber.Text.ToLower()
                                                                               + "?utm_source=qr_code&utm_medium=mapsheet&utm_campaign="
-                                                                              + tbxOperationId.Text.ToLower() + "&utm_content=" + tbxMapNumber.Text.ToLower() + "-v"
-                                                                              + tbxVersionNumber.Text);
+                                                                              //+ tbxOperationId.Text.ToLower() + "&utm_content=" + tbxMapNumber.Text.ToLower()
+                                                                              //+ "-v" + tbxVersionNumber.Text
+                                                                              + "-" + getPaddedVersionNumberString()
+                                                                              );
                             pPictureElement.ImportPictureFromFile(qrCodeImagePath);
                             qrCodeUpdated = true;
                         }

--- a/arcgis10_mapping_tools/MapActionToolbars/frmLayoutMain.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmLayoutMain.cs
@@ -120,8 +120,9 @@ namespace MapActionToolbars
             if (dict.ContainsKey("map_no"))
             {
                 setMapNumberAndVersion(dict["map_no"]);
-                dict["map_no"] = tbxMapNumber.Text;
-                dict["map_version"] = nudVersionNumber.Text;
+                // not sure why we were writing to dictionary here, which gets discarded
+                //dict["map_no"] = tbxMapNumber.Text;
+                //dict["map_version"] = nudVersionNumber.Text;
             }
             else
             {
@@ -200,7 +201,7 @@ namespace MapActionToolbars
             dict.Add("summary", this.tbxSummary.Text);
             dict.Add("data_sources", this.tbxDataSources.Text);
             dict.Add("map_no", this.tbxMapNumber.Text);
-            dict.Add("map_version", this.nudVersionNumber.Text);
+            dict.Add("map_version", getPaddedVersionNumberString());
             dict.Add("spatial_reference", this.tbxSpatialReference.Text);
             dict.Add("glide_no", this.tbxGlideNumber.Text);
             dict.Add("time_zone", this.tbxTimezone.Text);
@@ -277,6 +278,12 @@ namespace MapActionToolbars
             return stringSpatialRef;
         }
 
+        private String getPaddedVersionNumberString(int offset = 0)
+        {
+            var int_version = int.Parse(this.nudVersionNumber.Text) + offset;
+            return "v" + int_version.ToString("D2");
+        }
+
         public static void writeDictToLayoutElements(Dictionary<string, string> dict)
         {
             IPageLayout pLayout = _pMxDoc.PageLayout;
@@ -313,7 +320,7 @@ namespace MapActionToolbars
                         }
                         else if (el_name == "map_no")
                         {
-                            pTextElement.Text = dict["map_no"] + " v" + dict["map_version"];
+                            pTextElement.Text = dict["map_no"] + " " + dict["map_version"];
                         }
                         else if (el_name == "spatial_reference")
                         {
@@ -362,7 +369,8 @@ namespace MapActionToolbars
                             string qrCodeImagePath = Utilities.GenerateQRCode(_mapRootURL + _operationId.ToLower() +
                                                                               "-" + dict["map_no"].ToLower()
                                                                               + "?utm_source=qr_code&utm_medium=mapsheet&utm_campaign="
-                                                                              + _operationId.ToLower() + "&utm_content=" + dict["map_no"].ToLower() + "-v"
+                                                                              + _operationId.ToLower() + "&utm_content=" + dict["map_no"].ToLower() 
+                                                                              + "-"
                                                                               + dict["map_version"]);
 
                             if (System.IO.File.Exists(qrCodeImagePath))


### PR DESCRIPTION
Fixes #194

Version numbers are now specified as 2 digits throughout and with lowercase v, to match those generated by MapChef.

E.g. MA001-v01

This affects the display of the version on the layout, the folder that exported files go into, and the version parameter in the UTM tag of the QR code URL. 

If the MXD filename also contains a reference to MA number and version (e.g. MA001-v01-MyLovelyMap.mxd) then the tool will check that the versions described there match those on the map, and will warn the user to rename the MXD if not.

Finally, reference to the git commit hash of the code from which the tool was compiled is now baked in and displayed in the About dialog.