### PR TITLE
Fix export tool not detecting "New" status - single character typo

### DIFF
--- a/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
+++ b/arcgis10_mapping_tools/MapActionToolbars/frmExportMain.cs
@@ -60,7 +60,7 @@ namespace MapActionToolbars
         private const string _statusCorrection = "Correction";
         private const string _languageCodesXmlFileName = "language_codes.xml";
         private const string _eventConfigJsonFileName = "event_description.json";
-        private const string _initialVersionNumber = "1";
+        private const string _initialVersionNumber = "01";
         private const string _initialMapNumber = "MA001";
 
         private string _labelLanguage;


### PR DESCRIPTION
Applied this fix in January but seems I forgot to merge it to master. Doing now to generate latest release.